### PR TITLE
update all caliopen.web link on github to our entrypoint

### DIFF
--- a/caliopen_website/templates/layout/contact.jinja2
+++ b/caliopen_website/templates/layout/contact.jinja2
@@ -19,7 +19,7 @@
       <div class="big-icons">
         <article id="github">
           <h3>{{ _('Forker nous sur GitHub') }}</h3>
-          <a href="https://github.com/CaliOpen/caliopen.web" class="logo">{{ _('octopus Github') }}</a>
+          <a href="https://caliopen.github.io" class="logo">{{ _('octopus Github') }}</a>
         </article>
 
         <article id="email">

--- a/caliopen_website/templates/layout/home.jinja2
+++ b/caliopen_website/templates/layout/home.jinja2
@@ -32,7 +32,7 @@
 
         <article id="github">
           <h3>{{ _('CaliOpen sur GitHub') }}</h3>
-          <a href="https://github.com/CaliOpen/caliopen.web">{{ _('octopus Github') }}</a>
+          <a href="https://caliopen.github.io">{{ _('octopus Github') }}</a>
           <p>{{ _('Participer au développement du projet et s\'impliquer.') }}</p>
         </article>
 

--- a/caliopen_website/templates/layout/page.jinja2
+++ b/caliopen_website/templates/layout/page.jinja2
@@ -2,7 +2,7 @@
 
 {% block header %}
   {{ super() }}
-  <a href="https://github.com/CaliOpen/caliopen.web">
+  <a href="https://caliopen.github.io">
     <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/e7bbb0521b397edbd5fe43e7f760759336b5e05f/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" />
   </a>
 
@@ -74,7 +74,7 @@
         <div>
           <ul class="footer-links column">
             <li id="footer-link-community" class="list-title">{{ _('Communauté') }}</li>
-            <li id="footer-link-fork-us"><a href="https://github.com/CaliOpen/caliopen.web">{{ _('Forker nous sur GitHub') }}</a></li>
+            <li id="footer-link-fork-us"><a href="https://caliopen.github.io">{{ _('Forker nous sur GitHub') }}</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Use of caliopen.github.io everywhere where it was caliopen.web repository used
